### PR TITLE
Add git repo to package.json and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "us",
   "description": "A package for easily working with US and state metadata",
   "author": "Patrick Way <patrick@hexane.org>",
-  "version": "1.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patsplat/javascript-us.git"
+  },
+  "version": "1.1.1",
   "main": "us.js",
   "engines": {
     "node": ">= 0.4.1"


### PR DESCRIPTION
npm `WARN`s when no repo field is present in a module, so I added the repo info and bumped the patch version.
